### PR TITLE
Decrease max transaction TLL to 6 hours

### DIFF
--- a/src/AbstractService.php
+++ b/src/AbstractService.php
@@ -12,7 +12,7 @@ use SwedbankPaymentPortal\Options\ServiceOptions;
  */
 abstract class AbstractService
 {
-    private $TRANSACTION_TTL_IN_HOURS = 72; // 3 days.
+    private $TRANSACTION_TTL_IN_HOURS = 6;
     /**
      * @var TransactionRepositoryInterface
      */


### PR DESCRIPTION
As recommended by our swedbank rep when asking about why our transactions were being ignored and receiving back that we're sending too many requests.

From Swedbank rep:
“We forgot to update documentation. It should be each 15-20 min. We preparing new version, in new version this will be handled differently. Please update your cronjob to run script not ache minute but 15 or 20 min interval. 72 hours for expire is also overkill, it should be max 6 hour. Sorry for confusion.”

As the package already manages a default retry period of 20 minutes, no further changes should be required. 
It will still retry failed transactions 18 times within the 6 hour period, which is significantly less than the 216 times it would be doing with the 72 hour TTL. Hopefully this is enough to not block us.

Surprisingly documentation update is still "forgotten", but I'll leave that to the professionals.